### PR TITLE
prevent incorrect usage of PrefixFS & HiddenFS, do not allow passing …

### DIFF
--- a/prefixfs_fuzz_test.go
+++ b/prefixfs_fuzz_test.go
@@ -13,12 +13,16 @@ import (
 func FuzzPrefixFS(f *testing.F) {
 
 	var (
-		rootPath = CallerPathTmp()
-		rootFS   = NewTempDirPrefixFS(rootPath)
-		prefix   = filepath.FromSlash("/some/test/prefix/01/test/02")
-		fsys     = NewPrefixFS(rootFS, prefix)
-		fileName = "prefixfs_test.txt"
+		rootPath  = CallerPathTmp()
+		rootFS    = NewTempDirPrefixFS(rootPath)
+		prefix    = filepath.FromSlash("/some/test/prefix/01/test/02")
+		fsys, err = NewPrefixFS(rootFS, prefix)
+		fileName  = "prefixfs_test.txt"
 	)
+	if err != nil {
+		panic(err)
+	}
+
 	for _, seed := range []string{".", "/", "..", "\\", fileName} {
 		f.Add(seed)
 	}

--- a/volumefs.go
+++ b/volumefs.go
@@ -1,6 +1,7 @@
 package backupfs
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -32,7 +33,7 @@ func (v *VolumeFS) prefixPath(name string) (string, error) {
 
 	volumePrefix := filepath.VolumeName(name)
 	if volumePrefix != "" {
-		return "", syscall.EPERM
+		return "", fmt.Errorf("path must not contain a volume prefix: %s: %w", volumePrefix, syscall.EPERM)
 	}
 
 	return filepath.Clean(filepath.Join(v.volume, name)), nil


### PR DESCRIPTION
…of paths that contain a Volume prefix like C:, D:, etc. require the passed filesystem be a VolumeFS for that specific case.